### PR TITLE
Fix macFUSE path handling (remove osxfuse symlink workaround)

### DIFF
--- a/ArchiveMounter/AppDelegate.swift
+++ b/ArchiveMounter/AppDelegate.swift
@@ -10,7 +10,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ aNotification: Notification) {
         /* Check if FUSE for macOS installation is present */
         let manager: FileManager = FileManager.default
-        guard manager.fileExists(atPath: "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse") else {
+        guard manager.fileExists(atPath: "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse") else {
             let alert: NSAlert = NSAlert()
             alert.alertStyle = .critical
             alert.messageText = "FUSE for macOS is not installed"


### PR DESCRIPTION
Archive Mounter expected legacy osxfuse paths on macOS, which required users to create manual symlinks when using macFUSE.

This change updates the code to use the correct macFUSE paths directly, making the following workaround unnecessary:

- mount_macfuse -> mount_osxfuse symlink
- macfuse.fs -> osxfuse.fs symlink

Fixes #8